### PR TITLE
More relaxed URL regular expression

### DIFF
--- a/8ComicViewer.user.js
+++ b/8ComicViewer.user.js
@@ -1,16 +1,10 @@
 // ==UserScript==
 // @name         8Comic Viewer
 // @namespace    https://knowlet3389.blogspot.tw/
-// @version      1.64
+// @version      1.65
 // @description  Auto load 8comic pic.
 // @author       KNowlet
-// @include      /^http[s]?\:\/\/www.comicvip.com\/show\/.*$/
-// @include      /^http[s]?\:\/\/v.comicbus.com\/online\/.*$/
-// @include      /^http[s]?\:\/\/v.nowcomic.com\/online\/.*$/
-// @include      /^http[s]?\:\/\/www.comicgood.com\/online\/.*$/
-// @include      /^http[s]?\:\/\/www.comicbus.cc\/online\/.*$/
-// @include      /^http[s]?\:\/\/www.comicbus.me\/online\/.*$/
-// @include      /^http[s]?\:\/\/www.8899.click\/online\/.*$/
+// @include      /^http[s]?\:\/\/.*\/online\/.*\d+\.html(\?ch=\d+(-\d+)?)?$
 // @grant        none
 // @downloadURL  https://github.com/knowlet/8Comic-Viewer/raw/master/8ComicViewer.user.js
 // ==/UserScript==


### PR DESCRIPTION
由於8Comic的網址頻繁更換的關係，常常造成功能失效，而必須增加新的網址，所以我嘗試將網址的判斷變得更加寬鬆，來適應頻繁更換8Comic的網址。

表達式`^http[s]?\:\/\/.*\/online\/.*\d+.html(\?ch=\d+.*)?$`，目前能適應以下網址：
- https://www.comicbus.xyz/online/comic-10406.html
- https://www.comicbus.xyz/online/comic-10406.html?ch=1
- https://www.comicbus.xyz/online/comic-10406.html?ch=1-12